### PR TITLE
Add StopAsync method

### DIFF
--- a/MediaCaptureWPF/CapturePreview.cs
+++ b/MediaCaptureWPF/CapturePreview.cs
@@ -40,5 +40,10 @@ namespace MediaCaptureWPF
 
             await m_capture.StartPreviewToCustomSinkAsync(profile, (IMediaExtension)m_preview.MediaSink);
         }
+
+        public async Task StopAsync()
+        {
+            await m_capture.StopPreviewAsync();
+        }
     }
 }


### PR DESCRIPTION
...so you can navigate to a different user control or window without leaving the media capture device active